### PR TITLE
Add x64 solution configuration

### DIFF
--- a/src/Spss.sln
+++ b/src/Spss.sln
@@ -20,20 +20,34 @@ Project("{778DAE3C-4631-46EA-AA77-85C1314464D9}") = "SimpleDemo", "SimpleDemo\Si
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Debug|x64.Build.0 = Debug|Any CPU
 		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Debug|x86.Build.0 = Debug|Any CPU
+		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Release|x64.ActiveCfg = Release|Any CPU
+		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Release|x64.Build.0 = Release|Any CPU
 		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Release|x86.ActiveCfg = Release|Any CPU
 		{230E956E-FB2D-448E-AD4A-E90CB4BE2092}.Release|x86.Build.0 = Release|Any CPU
+		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Debug|x64.ActiveCfg = Debug|x64
+		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Debug|x64.Build.0 = Debug|x64
 		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Debug|x86.ActiveCfg = Debug|x86
 		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Debug|x86.Build.0 = Debug|x86
+		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Release|x64.ActiveCfg = Release|x86
+		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Release|x64.Build.0 = Release|x86
 		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Release|x86.ActiveCfg = Release|x86
 		{87954EEF-2A60-444B-A1D0-1E94C2C663F1}.Release|x86.Build.0 = Release|x86
+		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Debug|x64.Build.0 = Debug|Any CPU
 		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Debug|x86.Build.0 = Debug|Any CPU
+		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Release|x64.ActiveCfg = Release|Any CPU
+		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Release|x64.Build.0 = Release|Any CPU
 		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Release|x86.ActiveCfg = Release|Any CPU
 		{7D996EAE-1C78-4E18-954F-882BE7AA6E99}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection


### PR DESCRIPTION
This allows us to build and test the x64 project configuration of the test project.
Note that the Test -> Test Settings -> Default Processor Architecture must be set to match the solution configuration's platform for the test explorer to run tests properly.